### PR TITLE
chore(ci): add concurrency groups, path filters, codegen verification

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - 'lepticons/**'
+      - 'lepticons-picker/**'
+      - 'lepticons-animate/**'
+      - 'demo/**'
+      - 'Cargo.*'
   pull_request:
     branches:
       - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   TRUNK_VERSION: "0.21.14"
@@ -48,5 +52,5 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         env:
           TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        working-directory: ${{ github.workspace }}/demo/dist
+        working-directory: demo/dist
         run: vercel deploy --prod --token="$TOKEN"

--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -55,6 +55,10 @@ jobs:
           cargo run --bin lepticons-codegen
           cd ..
 
+      - name: Verify generated code
+        if: steps.check.outputs.changed == 'true'
+        run: cargo clippy -p lepticons --all-targets -- -D warnings
+
       - name: Count icons
         if: steps.check.outputs.changed == 'true'
         id: count


### PR DESCRIPTION
Preview: add path filters to skip deploys on doc-only changes, add concurrency group to cancel superseded runs.
Release: normalize working-directory, add concurrency group. Update-icons: verify generated code compiles after codegen.